### PR TITLE
A few small fixes to the install and manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ coredns-opa
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+deploy/kubeconfig

--- a/deploy/base/deployment.yaml
+++ b/deploy/base/deployment.yaml
@@ -94,8 +94,8 @@ spec:
         - "run"
         - "--ignore=.*"  # exclude hidden dirs created by Kubernetes
         - "--server"
-        - "--addr=127.0.0.1:8282"
-        - "--log-level=debug"
+        - "--addr=0.0.0.0:8282"
+        - "--set=decision_logs.console=true"
         - "/policies"
         volumeMounts:
         - readOnly: true
@@ -104,12 +104,13 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTP
+            path: /health
             port: 8282
           initialDelaySeconds: 5
           periodSeconds: 5
         readinessProbe:
           httpGet:
-            path: /health?bundle=true  # Include bundle activation in readiness
+            path: /health
             scheme: HTTP
             port: 8282
           initialDelaySeconds: 5

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -10,8 +10,10 @@ configMapGenerator:
 - files:
   - Corefile
   name: coredns
+  namespace: kube-system
 - files:
   - coredns.rego
   name: coredns-opa-policies
+  namespace: kube-system
 generatorOptions:
   disableNameSuffixHash: true

--- a/deploy/cluster.sh
+++ b/deploy/cluster.sh
@@ -8,6 +8,7 @@ GCP_QUIET=""
 force=n
 create=n
 delete=n
+allow_source_range=""
 
 while [[ $# -gt 0 ]]
 do
@@ -18,6 +19,10 @@ do
       ;;
     --dry-run)
       GCP_DRYRUN=y
+      ;;
+    --allow-source-range)
+      allow_source_range=$2
+      shift
       ;;
     -c)
       create=y
@@ -38,12 +43,13 @@ fi
 
 if [[ -z $cluster ]]; then
   echo
-  echo Usage: $0 [ --force ] [ --dry-run ] [ -c ] [ -d ] clustername
+  echo Usage: $0 [ --force ] [ --dry-run ] [ -c ] [ -d ] clustername [ --allow-source-range cidr ]
   echo
   echo "  -c means create the cluster"
   echo "  -d means delete the cluster"
   echo " --force means it won't prompt you before doing anything"
   echo " --dry-run means it won't actually execute mutating gcloud and kubectl commands"
+  echo " --allow-source-range CIDR tells gcloud to permit inbound connections to the cluster from this CIDR"
   echo
   echo If neither -c nor -d is specified, the cluster will be deleted then created.
   exit 1
@@ -56,7 +62,13 @@ if [[ $delete == "y" ]]; then
 fi
 
 if [[ $create == "y" ]]; then
-  gke_create_isolated_zonal_cluster $cluster
+
+  if [[ -z "$allow_source_range" ]]; then
+    echo "missing --allow-source-range <cidr>: specify CIDR to allow inbound connections from (e.g., '<YOUR_PUBLIC_IP>/32')"
+    exit 1
+  fi
+
+  gke_create_isolated_zonal_cluster $cluster $allow_source_range
 
   gke_get_credentials $cluster
   gke_clusteradmin_account $cluster


### PR DESCRIPTION
These changes are pretty self-explanatory. The second forces you to specify a source IP range to permit inbound connections from (otherwise it defaults to a Google corporate subnet.)

With the last change in place we can see OPA being queried by CoreDNS. Here is an example:

```json
{
  "decision_id": "8b985c80-1bdc-4753-8fd1-668653a35e74",
  "input": {
    "client_ip": "10.0.0.4",
    "name": "logging.googleapis.com.c.new-expo.internal.",
    "rcode": "",
    "response_ip": ""
  },
  "labels": {
    "id": "07445c48-d0fa-4bd0-95a1-e09dc8691f9d",
    "version": "0.16.0"
  },
  "level": "info",
  "metrics": {
    "counter_server_query_cache_hit": 1,
    "timer_rego_input_parse_ns": 48266,
    "timer_rego_query_eval_ns": 120592,
    "timer_server_handler_ns": 196599
  },
  "msg": "Decision Log",
  "path": "dns/action",
  "requested_by": "127.0.0.1:34640",
  "result": "allow",
  "time": "2020-01-11T18:30:12Z",
  "timestamp": "2020-01-11T18:30:12.537644264Z",
  "type": "openpolicyagent.org/decision_logs"
}
```